### PR TITLE
Feature/update dependencies

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,152 @@
+{
+	"ImportPath": "github.com/aacebedo/docker-events",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v74",
+	"Deps": [
+		{
+			"ImportPath": "github.com/Microsoft/go-winio",
+			"Comment": "v0.3.5-2-gce2922f",
+			"Rev": "ce2922f643c8fd76b46cadc7f404a06282678b34"
+		},
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.10.0-38-g3ec0642",
+			"Rev": "3ec0642a7fb6488f65b06f9040adc67e3990296a"
+		},
+		{
+			"ImportPath": "github.com/docker/distribution/digest",
+			"Comment": "docs-v2.4.1-2016-06-28-128-g431cfa3",
+			"Rev": "431cfa3179d9b3766e39f6a74283db8bb5a13209"
+		},
+		{
+			"ImportPath": "github.com/docker/distribution/reference",
+			"Comment": "docs-v2.4.1-2016-06-28-128-g431cfa3",
+			"Rev": "431cfa3179d9b3766e39f6a74283db8bb5a13209"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/blkiodev",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/container",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/events",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/filters",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/mount",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/network",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/reference",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/registry",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/strslice",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/swarm",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/time",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/api/types/versions",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/client",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/tlsconfig",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-1648-g4348878",
+			"Rev": "434887824241806f6bc0a686966245c569778c00"
+		},
+		{
+			"ImportPath": "github.com/docker/go-connections/nat",
+			"Comment": "v0.2.1-4-g988efe9",
+			"Rev": "988efe982fdecb46f01d53465878ff1f2ff411ce"
+		},
+		{
+			"ImportPath": "github.com/docker/go-connections/sockets",
+			"Comment": "v0.2.1-4-g988efe9",
+			"Rev": "988efe982fdecb46f01d53465878ff1f2ff411ce"
+		},
+		{
+			"ImportPath": "github.com/docker/go-connections/tlsconfig",
+			"Comment": "v0.2.1-4-g988efe9",
+			"Rev": "988efe982fdecb46f01d53465878ff1f2ff411ce"
+		},
+		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.3.1-6-gf2145db",
+			"Rev": "f2145db703495b2e525c59662db69a7344b00bb8"
+		},
+		{
+			"ImportPath": "github.com/opencontainers/runc/libcontainer/user",
+			"Comment": "v1.0.0-rc1-214-gce5d8cf",
+			"Rev": "ce5d8cf94124a683af6a874f343375d3ec9230b4"
+		},
+		{
+			"ImportPath": "github.com/pkg/errors",
+			"Comment": "v0.7.1-1-ga887431",
+			"Rev": "a887431f7f6ef7687b556dbf718d9f351d4858a0"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "b6d7b1396ec874c3b00f6c84cd4301a17c56c8ed"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context/ctxhttp",
+			"Rev": "b6d7b1396ec874c3b00f6c84cd4301a17c56c8ed"
+		},
+		{
+			"ImportPath": "golang.org/x/net/proxy",
+			"Rev": "b6d7b1396ec874c3b00f6c84cd4301a17c56c8ed"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "62bee037599929a6e9146f29d10dd5208c43507d"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/windows",
+			"Rev": "62bee037599929a6e9146f29d10dd5208c43507d"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/events.go
+++ b/events.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
-	eventtypes "github.com/docker/engine-api/types/events"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/types"
+	eventtypes "github.com/docker/docker/api/types/events"
 )
 
 // Monitor subscribes to the docker events api using engine api and will execute the

--- a/events_test.go
+++ b/events_test.go
@@ -12,9 +12,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
-	eventtypes "github.com/docker/engine-api/types/events"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/types"
+	eventtypes "github.com/docker/docker/api/types/events"
 )
 
 func TestMonitorError(t *testing.T) {

--- a/handlers.go
+++ b/handlers.go
@@ -3,7 +3,7 @@ package events
 import (
 	"sync"
 
-	eventtypes "github.com/docker/engine-api/types/events"
+	eventtypes "github.com/docker/docker/api/types/events"
 )
 
 // NewHandler creates an event handler using the specified function to qualify the message

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	eventtypes "github.com/docker/engine-api/types/events"
+	eventtypes "github.com/docker/docker/api/types/events"
 )
 
 func TestByType(t *testing.T) {

--- a/nop_test.go
+++ b/nop_test.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
 )
 
 var (


### PR DESCRIPTION
Hi !
Docker has deprecated the engine-api and moved it back to the docker main repo.
I have updated your project with this info.
Can you integrate it please ?

Note: I have also added a Godep file :)
